### PR TITLE
Allow dot '.' in json key names

### DIFF
--- a/ghetto_json
+++ b/ghetto_json
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 
+# from https://github.com/FauxFaux/ansible-ghetto-json
+
 import json
+
 import sys
 import shlex
+import re
 
 try:
     import commentjson
@@ -16,9 +20,13 @@ def main(params_list):
     changed = False
 
     with open(path) as f:
-        obj = json_load(f)
+        obj = json.load(f)
         for (key, target) in params.items():
-            parts = key.split('.')
+            #if the key has a '.' in the name, cant necessarily assume it's a level down the hierarchy
+            #allow escaping with '\'; then need to remove the escape
+            parts = re.split(r'(?<!\\)\.', key)
+            parts = [part.replace('\.','.') for part in parts]
+
             ref = obj
             for part in parts[:-1]:
                 if part not in ref:
@@ -39,7 +47,7 @@ def main(params_list):
                     target = False
                 if target == 'true':
                     target = True
-                if last_part not in ref or ref[last_part] != target:
+                if last_part not in ref or ref[last_part] != target:                    
                     ref[last_part] = target
                     changed = True
 

--- a/ghetto_json
+++ b/ghetto_json
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-# from https://github.com/FauxFaux/ansible-ghetto-json
-
 import json
-
 import sys
 import shlex
 import re
@@ -20,10 +17,8 @@ def main(params_list):
     changed = False
 
     with open(path) as f:
-        obj = json.load(f)
+        obj = json_load(f)
         for (key, target) in params.items():
-            #if the key has a '.' in the name, cant necessarily assume it's a level down the hierarchy
-            #allow escaping with '\'; then need to remove the escape
             parts = re.split(r'(?<!\\)\.', key)
             parts = [part.replace('\.','.') for part in parts]
 

--- a/ghetto_json
+++ b/ghetto_json
@@ -42,7 +42,7 @@ def main(params_list):
                     target = False
                 if target == 'true':
                     target = True
-                if last_part not in ref or ref[last_part] != target:                    
+                if last_part not in ref or ref[last_part] != target:
                     ref[last_part] = target
                     changed = True
 


### PR DESCRIPTION
Added a positive lookbehind to add a slash '\' before a dot '.' in json key names.

I needed this for openvpn config file

`
{
  "Default": {
    "admin_ui.https.ip_address": "all",
    "admin_ui.https.port": "943" 
  }
}
`

in your ansible yaml file

`
'Default.admin_ui\.https\.port'="944"
`

The single quotes are needed around the parameter or else ansible escapes the backslash when passing as a parameter to ghetto-json
