### PR TITLE
Fix crash when value contains `=`

### DIFF
--- a/ghetto_json
+++ b/ghetto_json
@@ -11,7 +11,7 @@ except ImportError:
     json_load = json.load
 
 def main(params_list):
-    params = dict(x.split("=", 2) for x in params_list)
+    params = dict(x.split("=", 1) for x in params_list)
     path = params.pop('path')
     changed = False
 


### PR DESCRIPTION
If the value contains an equal sign (`=`), we get a crash

`ValueError: dictionary update sequence element #3 has length 3; 2 is required`